### PR TITLE
NOJIRA: fix githubDocRoot so that 'Edit on GitHub' link works

### DIFF
--- a/docpad.js
+++ b/docpad.js
@@ -11,7 +11,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
 // This project's repository on GitHub. Used to build URLs for "Edit on GitHub" links
 // Change this value to match your site.
-var githubDocRoot = "https://github.com/inclusive-design/guides.inclusivedesign.ca/tree/master/src/documents/";
+var githubDocRoot = "https://github.com/inclusive-design/guide.inclusivedesign.ca/tree/master/src/documents/";
 
 var path = require("path");
 var fs = require("fs");


### PR DESCRIPTION
This updates the `githubDocRoot` variable to the current repo name so that the `getGithubLocation` helper works to generate a correct link to the document in GitHub.

@jhung please merge if this look ok - tested it locally.