### PR TITLE
FLUID-5941 hotfix - make sidebar show in IE11

### DIFF
--- a/src/documents/css/docs-template.css.styl
+++ b/src/documents/css/docs-template.css.styl
@@ -607,7 +607,7 @@ html body {
 }
 
 .docs-core-sidebar-expanded .docs-template-topics {
-    display: initial; // restore tabbability of topics
+    display: block; // restore tabbability of topics
 }
 
 .docs-template-topics-hideShow {
@@ -671,14 +671,14 @@ html body {
     li {
         padding: 0.6rem 0.2rem 0.6rem 0;
     }
-    
-/*! 
+
+/*!
 .docs-template-topics-active:before {
- 
+
         content: "\2590";
         display: inline-block;
         margin-right: 0.2rem;
-    } 
+    }
 */
 
     a {


### PR DESCRIPTION
A hotfix specific to the design guide site which fixes a problem in
IE11 with the sidebar contents not appearing.

This only fixes the problem for the Guides site. There is a separate
pull request to fix this generally in the docs-template repo.