### PR TITLE
IDI-153: SVG height fixes layout issues in IE and Edge

### DIFF
--- a/src/documents/css/idg.css.styl
+++ b/src/documents/css/idg.css.styl
@@ -183,6 +183,7 @@ a:hover .idg-logo {
 .idg-iconTools svg,
 .idg-iconActivities svg {
     width: 1rem;
+    height: 1rem; //width and height required by IE11.
 }
 
 .idg-iconPrinciples svg {
@@ -260,6 +261,7 @@ setNavTab(inputColor) {
         fill: #fff;
         margin-right: 0.5rem;
         width: 1.2rem;
+        height: 1.2rem; // width and height required for IE11.
     }
 
     .idg-navPrinciples {


### PR DESCRIPTION
This fixes IDI-151, 152, and 153. The SVGs now look okay and the tabs look proper sized.

@jobara can you take a look at this?