### PR TITLE
NO-JIRA: Added dev dependency for Docpad 6.79 to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "docpad-plugin-stylus": "~2.10.0",
     "docs-core": "fluid-project/docs-core"
   },
+  "devDependencies": {
+    "docpad": "~6.79"
+  },
   "licenses": [
     {
       "type": "BSD-3-Clause",


### PR DESCRIPTION
This should fix the issue with the CI not building the site.

@gtirloni can you take a look at this?