### PR TITLE
Remove redirects from DocPad (moved to load balancer)

### DIFF
--- a/docpad.js
+++ b/docpad.js
@@ -44,24 +44,6 @@ module.exports = {
         siteStructure: siteStructure
     },
     plugins: {
-        redirector: {
-            redirects: {
-                "/insights/":"/insights/DiverseParticipationAndPerspectives.html",
-                "/practices/":"/practices/Collaborate.html",
-                "/tools/":"/tools/UXWalkthroughs.html",
-                "/activities/":"/activities/MatchingGame.html",
-                "/principles/":"/insights/",
-                "/principles/DiverseParticipationAndPerspectives.html": "/insights/DiverseParticipationAndPerspectives.html",
-                "/principles/AutonomousUser.html": "/insights/PersonalDiscovery.html",
-                "/principles/DisabilityAsMismatch.html": "/insights/DisabilityAsMismatch.html",
-                "/principles/IntegratedSolutions.html": "/insights/IntegratedSolutions.html",
-                "/principles/Interconnectedness.html": "/insights/Interconnectedness.html",
-                "/principles/OneSizeFitsOne.html": "/insights/OneSizeFitsOne.html",
-                "/principles/UserContinuedDesign.html": "/insights/UserContinuedDesign.html",
-                "/principles/VirtuousCycles.html": "/insights/VirtuousCycles.html",
-                "/insights/AutonomousUser.html": "/insights/PersonalDiscovery.html"
-            }
-        },
         handlebars: {
             helpers: {
                 rewriteMdLinks: docsCore.helpers.rewriteMdLinks,


### PR DESCRIPTION
These redirects are being done at the load balancer level in preparation to the migration to 11ty. Having them here in DocPad causes redirects loops.